### PR TITLE
JCN 297 bug list safe list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `list` and `safeList` wrong default `endpointParameters` value
 
 ## [4.1.0] - 2020-05-05
 ### Added

--- a/lib/microservice-call.js
+++ b/lib/microservice-call.js
@@ -178,7 +178,7 @@ class MicroServiceCall {
 	 * @param {Object} filters The query params to filter/order the list
 	 * @returns {Object} Returns the response, in the body the full list of objects
 	 */
-	async list(service, namespace, filters = null, endpointParameters = null) {
+	async list(service, namespace, filters = null, endpointParameters) {
 
 		const body = [];
 		let page = 1;
@@ -208,7 +208,7 @@ class MicroServiceCall {
 	 * @param {Object} filters The query params to filter/order the list
 	 * @returns {Object} Returns the response, in the body the full list of objects
 	 */
-	async safeList(service, namespace, filters = null, endpointParameters = null) {
+	async safeList(service, namespace, filters = null, endpointParameters) {
 
 		const body = [];
 		let page = 1;

--- a/tests/microservice-call.js
+++ b/tests/microservice-call.js
@@ -586,7 +586,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 		});
 
@@ -615,7 +615,7 @@ describe('MicroService call', () => {
 				'list',
 				{ filters: { status: 'active' } },
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 		});
 
@@ -692,7 +692,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 
 			sinon.assert.calledWithExactly(MicroServiceCall.prototype.call,
@@ -701,7 +701,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 2 },
-				null
+				undefined
 			);
 
 			sinon.assert.calledWithExactly(MicroServiceCall.prototype.call,
@@ -710,7 +710,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 3 },
-				null
+				undefined
 			);
 		});
 
@@ -735,7 +735,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 		});
 
@@ -769,7 +769,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 
 			sinon.assert.calledWithExactly(MicroServiceCall.prototype.call,
@@ -778,7 +778,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 2 },
-				null
+				undefined
 			);
 		});
 	});
@@ -810,7 +810,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 		});
 
@@ -839,7 +839,7 @@ describe('MicroService call', () => {
 				'list',
 				{ filters: { status: 'active' } },
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 		});
 
@@ -916,7 +916,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 
 			sinon.assert.calledWithExactly(MicroServiceCall.prototype.safeCall,
@@ -925,7 +925,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 2 },
-				null
+				undefined
 			);
 
 			sinon.assert.calledWithExactly(MicroServiceCall.prototype.safeCall,
@@ -934,7 +934,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 3 },
-				null
+				undefined
 			);
 		});
 
@@ -961,7 +961,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 		});
 
@@ -997,7 +997,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 1 },
-				null
+				undefined
 			);
 
 			sinon.assert.calledWithExactly(MicroServiceCall.prototype.safeCall,
@@ -1006,7 +1006,7 @@ describe('MicroService call', () => {
 				'list',
 				null,
 				{ 'x-janis-page': 2 },
-				null
+				undefined
 			);
 		});
 	});


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-298

**DESCRIPCIÓN DEL REQUERIMIENTO**

Problema
En el package Microservice-call  al usar los metodos list y safeList a partir de la versión 1.1.0, sino se pasa el parametro endpointParameters, arroja un error que no deberia.

Requerimiento
Se requiere eliminar el valor por defecto null en el parametro endpointParameters de los metodos list y safeList

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados