### PR TITLE
Jcn 461 implement userid set in api key base header

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ _Since 4.0.0_
 
 > :warning: **After version 4.0.0, `get`, `post`, `put`, `path`, `delete` are *REMOVED***  :warning:
 
+_Since 5.1.0_
+
+* `set apiKeyUserId()`
+	Setter for add user id in api-key header
+
 ## Parameters
 
 The Parameters used in the API functions.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,13 @@ _Since 4.0.0_
 
 _Since 5.1.0_
 
-* `set apiKeyUser()`
-	Setter for add user id in api-key header
+* `setUserId(userId)`
+
+	Function for add user id in api-key header
+
+	Params: `userId` `{String}`
+
+	Returns a `MicroServiceCallInstance`.
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ _Since 4.0.0_
 
 _Since 5.1.0_
 
-* `set apiKeyUserId()`
+* `set apiKeyUser()`
 	Setter for add user id in api-key header
 
 ## Parameters

--- a/lib/microservice-call.js
+++ b/lib/microservice-call.js
@@ -68,7 +68,7 @@ module.exports = class MicroServiceCall {
 
 		const servicePart = `service-${process.env.JANIS_SERVICE_NAME}`;
 
-		const userPart = this._apiKeyUser ? `_user-${this._apiKeyUser}` : '';
+		const userPart = this.apiKeyUser ? `_user-${this.apiKeyUser}` : '';
 
 		return {
 			'janis-api-key': `${servicePart}${userPart}`,
@@ -100,9 +100,13 @@ module.exports = class MicroServiceCall {
 	/**
 	 * Set userId for make api-key header
 	 * @param {string} userId User identifier
+	 * @returns {MicroServiceCall}
 	 */
-	set apiKeyUser(userId) {
-		this._apiKeyUser = userId;
+	setUserId(userId) {
+
+		this.apiKeyUser = userId;
+
+		return this;
 	}
 
 	/**
@@ -117,6 +121,9 @@ module.exports = class MicroServiceCall {
 			...this.credentialsHeaders,
 			...this.sessionHeaders
 		};
+
+		// clear user id for api key
+		this.apiKeyUser = null;
 
 		return basic;
 	}

--- a/lib/microservice-call.js
+++ b/lib/microservice-call.js
@@ -68,10 +68,10 @@ module.exports = class MicroServiceCall {
 
 		const servicePart = `service-${process.env.JANIS_SERVICE_NAME}`;
 
-		const userIdPart = this._apiKeyUserId ? `_user-${this._apiKeyUserId}` : '';
+		const userPart = this._apiKeyUser ? `_user-${this._apiKeyUser}` : '';
 
 		return {
-			'janis-api-key': `${servicePart}${userIdPart}`,
+			'janis-api-key': `${servicePart}${userPart}`,
 			'janis-api-secret': SecretFetcher.secretValue
 		};
 	}
@@ -101,8 +101,8 @@ module.exports = class MicroServiceCall {
 	 * Set userId for make api-key header
 	 * @param {string} userId User identifier
 	 */
-	set apiKeyUserId(userId) {
-		this._apiKeyUserId = userId;
+	set apiKeyUser(userId) {
+		this._apiKeyUser = userId;
 	}
 
 	/**

--- a/lib/microservice-call.js
+++ b/lib/microservice-call.js
@@ -65,8 +65,13 @@ module.exports = class MicroServiceCall {
 	 * @returns {CredentialHeaders}
 	 */
 	get credentialsHeaders() {
+
+		const servicePart = `service-${process.env.JANIS_SERVICE_NAME}`;
+
+		const userIdPart = this._apiKeyUserId ? `_user-${this._apiKeyUserId}` : '';
+
 		return {
-			'janis-api-key': `service-${process.env.JANIS_SERVICE_NAME}`,
+			'janis-api-key': `${servicePart}${userIdPart}`,
 			'janis-api-secret': SecretFetcher.secretValue
 		};
 	}
@@ -90,6 +95,14 @@ module.exports = class MicroServiceCall {
 		}
 
 		return sessionHeaders;
+	}
+
+	/**
+	 * Set userId for make api-key header
+	 * @param {string} userId User identifier
+	 */
+	set apiKeyUserId(userId) {
+		this._apiKeyUserId = userId;
 	}
 
 	/**

--- a/tests/microservice-call.js
+++ b/tests/microservice-call.js
@@ -1346,7 +1346,7 @@ describe('MicroService call', () => {
 		});
 	});
 
-	describe('Using apiKeyUser setter', () => {
+	describe('Using setUserId function', () => {
 
 		beforeEach(() => {
 			process.env.JANIS_SERVICE_SECRET = 'insecure-secret';
@@ -1381,11 +1381,11 @@ describe('MicroService call', () => {
 				'janis-api-key': 'service-dummy-service_user-5f4adc8f9c4ae13ea8000000'
 			};
 
-			ms.apiKeyUser = '5f4adc8f9c4ae13ea8000000';
-
 			mockRequest(reqheaders);
 
-			await ms.call(...requestArgs);
+			await ms
+				.setUserId('5f4adc8f9c4ae13ea8000000')
+				.call(...requestArgs);
 
 			secretsNotCalled(sinon);
 		});
@@ -1397,29 +1397,27 @@ describe('MicroService call', () => {
 				'janis-api-key': 'service-dummy-service'
 			};
 
-			ms.apiKeyUser = null;
-
 			mockRequest(reqheaders);
 
-			await ms.call(...requestArgs);
+			await ms
+				.setUserId(null)
+				.call(...requestArgs);
 
 			secretsNotCalled(sinon);
 		});
 
-		it('Should set and remove user id in janis-api-key header', async () => {
+		it('Should set and clear user id in janis-api-key header', async () => {
 
 			const reqheaders = {
 				...baseRequestHeaders,
 				'janis-api-key': 'service-dummy-service_user-5f4adc8f9c4ae13ea8000000'
 			};
 
-			ms.apiKeyUser = '5f4adc8f9c4ae13ea8000000';
-
 			mockRequest(reqheaders);
 
-			await ms.call(...requestArgs);
-
-			ms.apiKeyUser = null;
+			await ms
+				.setUserId('5f4adc8f9c4ae13ea8000000')
+				.call(...requestArgs);
 
 			mockRequest({ ...reqheaders, 'janis-api-key': 'service-dummy-service' });
 

--- a/tests/microservice-call.js
+++ b/tests/microservice-call.js
@@ -1346,7 +1346,7 @@ describe('MicroService call', () => {
 		});
 	});
 
-	describe('Using apiKeyUserId setter', () => {
+	describe('Using apiKeyUser setter', () => {
 
 		beforeEach(() => {
 			process.env.JANIS_SERVICE_SECRET = 'insecure-secret';
@@ -1381,7 +1381,7 @@ describe('MicroService call', () => {
 				'janis-api-key': 'service-dummy-service_user-5f4adc8f9c4ae13ea8000000'
 			};
 
-			ms.apiKeyUserId = '5f4adc8f9c4ae13ea8000000';
+			ms.apiKeyUser = '5f4adc8f9c4ae13ea8000000';
 
 			mockRequest(reqheaders);
 
@@ -1397,7 +1397,7 @@ describe('MicroService call', () => {
 				'janis-api-key': 'service-dummy-service'
 			};
 
-			ms.apiKeyUserId = null;
+			ms.apiKeyUser = null;
 
 			mockRequest(reqheaders);
 
@@ -1413,13 +1413,13 @@ describe('MicroService call', () => {
 				'janis-api-key': 'service-dummy-service_user-5f4adc8f9c4ae13ea8000000'
 			};
 
-			ms.apiKeyUserId = '5f4adc8f9c4ae13ea8000000';
+			ms.apiKeyUser = '5f4adc8f9c4ae13ea8000000';
 
 			mockRequest(reqheaders);
 
 			await ms.call(...requestArgs);
 
-			ms.apiKeyUserId = null;
+			ms.apiKeyUser = null;
 
 			mockRequest({ ...reqheaders, 'janis-api-key': 'service-dummy-service' });
 


### PR DESCRIPTION
**LINK AL TICKET**
https://janiscommerce.atlassian.net/browse/JCN-460
https://janiscommerce.atlassian.net/browse/JCN-461

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se debe un crear un nuevo método donde se pueda agregar el user para poder agregarselo al api-key que genera el ms call.
El nuevo header _janis-api-key_ debería quedar así si es que se le pasa el user (_service-janis-oms_user-65779d4398b9e6a853d1c9f0_) .
El porque se necesita esto esta mucho mas explicado en https://janiscommerce.atlassian.net/browse/ATR-1021

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agregó una funcion(_setUserId_) nuevo en la clase de Ms Call para poder setear un userId, que se utilizara para la generacion del header _janis-api-key_

**Como se puede probar**
Esto se va utilizar en el servicio de batch para hacer los exports. Para que no se cacheen las request al servicio a exportar cuando se exporte un listado casi al mismo tiempo por disitintos usuarios.

Changelog
```
### Added

- Add function to add userId in header janis-api-key
```