### PR TITLE
Validate invoker response

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Invoker } = require('@janiscommerce/lambda');
+const MicroServiceCallError = require('./microservice-call-error');
 
 let cache = {};
 
@@ -12,7 +13,22 @@ module.exports = class Discovery {
 
 		if(!cache[cacheKey]) {
 
-			const { payload: { baseUrl, path, method: httpMethod } } = await Invoker.serviceCall('discovery', 'GetEndpoint', { service, namespace, method });
+			const {
+				payload: { baseUrl, path, method: httpMethod, errorMessage },
+				functionError
+			} = await Invoker.serviceCall('discovery', 'GetEndpoint', { service, namespace, method });
+
+			const errorMsg = errorMessage || functionError;
+
+			if(errorMsg)
+				throw new MicroServiceCallError(`Service Discovery fails getting endpoint. Error: ${errorMsg}`, MicroServiceCallError.codes.DISCOVERY_ERROR);
+
+			if(!baseUrl || !path || !httpMethod) {
+				throw new MicroServiceCallError(
+					`Could not get base url, path or method. Base url: ${baseUrl}, path: ${path}, method: ${httpMethod}`,
+					MicroServiceCallError.codes.DISCOVERY_ERROR
+				);
+			}
 
 			const endpoint = `${baseUrl}${path}`;
 

--- a/lib/microservice-call-error.js
+++ b/lib/microservice-call-error.js
@@ -6,7 +6,8 @@ module.exports = class MicroServiceCallError extends Error {
 		return {
 			MICROSERVICE_FAILED: 2,
 			REQUEST_LIB_ERROR: 3,
-			JANIS_SECRET_MISSING: 4
+			JANIS_SECRET_MISSING: 4,
+			DISCOVERY_ERROR: 5
 		};
 	}
 

--- a/tests/microservice-call.js
+++ b/tests/microservice-call.js
@@ -1345,4 +1345,41 @@ describe('MicroService call', () => {
 			secretsNotCalled(sinon);
 		});
 	});
+
+	describe('Discovery service fails', () => {
+
+		it('Should throw an error if it has an error message', async () => {
+
+			getEndpointStub({
+				errorMessage: 'An error occurred'
+			});
+
+			await assert.rejects(() => ms.call('sample-service', 'sample-entity', 'list'), {
+				name: 'MicroServiceCallError',
+				code: MicroServiceCallError.codes.DISCOVERY_ERROR,
+				message: 'Service Discovery fails getting endpoint. Error: An error occurred'
+			});
+
+			assertGetEndpoint('sample-service', 'sample-entity', 'list');
+		});
+
+		it('Should throw an error if it has no base url, path or method', async () => {
+
+			const baseUrl = 'https://sample-service.janis-test.in';
+			const path = '/api/sample-entity';
+
+			getEndpointStub({
+				baseUrl,
+				path
+			});
+
+			await assert.rejects(() => ms.call('sample-service', 'sample-entity', 'list'), {
+				name: 'MicroServiceCallError',
+				code: MicroServiceCallError.codes.DISCOVERY_ERROR,
+				message: `Could not get base url, path or method. Base url: ${baseUrl}, path: ${path}, method: undefined`
+			});
+
+			assertGetEndpoint('sample-service', 'sample-entity', 'list');
+		});
+	});
 });


### PR DESCRIPTION
**LINK AL TICKET**
https://janiscommerce.atlassian.net/browse/JCN-463
https://janiscommerce.atlassian.net/browse/JCN-464

**DESCRIPCIÓN DEL REQUERIMIENTO**
Manejar errores que puede devolver Invoker.serviceCall

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agrego una validacion por si viene la propiedad functionError o errorMessage dentro del payload, tambien se valida el payload tiene baseUrl, path y method.

**Changelog**

```
### Added

- Validations for the Invoker response to the Discovery GetEnpoint call
```